### PR TITLE
fix #29: peerreview中删除独创性声明 …

### DIFF
--- a/install/buptgraduatethesis.dtx
+++ b/install/buptgraduatethesis.dtx
@@ -2331,7 +2331,10 @@
     \bupt@inside@front@cover
     \ifnum\bupt@degree=3
     \else
+      \ifnum\bupt@finish=2
+      \else
       \bupt@makedeclauth
+      \fi
     \fi
   \end{titlepage}
   \ifbupt@class@dedication


### PR DESCRIPTION
(reverted from commit ee9cd28e81c5e83f99167a30edd18ed197afa5b6)

@rioxwang 学校前后的文档并不一致……

- 对于5%的学生要求提交的盲审是要包含独创性声明和授权
- 对于100%的学生要提交的最终版又要删除独创性声明和授权

所以，我还是觉得撤销上一次的更改，恢复成删除的比较合适。